### PR TITLE
[FEAT] JWT 기반 로그인/로그아웃 및 토큰 재발급 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'at.favre.lib:bcrypt:0.10.2'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/outsourcing/config/PasswordEncoder.java
+++ b/src/main/java/com/example/outsourcing/config/PasswordEncoder.java
@@ -1,0 +1,33 @@
+package com.example.outsourcing.config;
+
+import org.springframework.stereotype.Component;
+
+import at.favre.lib.crypto.bcrypt.BCrypt;
+
+/**
+ * 비밀번호 암호화 및 검증을 위한 유틸리티 클래스입니다.
+ */
+@Component
+public class PasswordEncoder {
+
+	/**
+	 * 비밀번호를 Bcrypt로 인코딩합니다.
+	 *
+	 * @param rawPassword 원문 비밀번호
+	 * @return 암호화된 문자열
+	 */
+	public String encode(String rawPassword) {
+		return BCrypt.withDefaults().hashToString(BCrypt.MIN_COST, rawPassword.toCharArray());
+	}
+
+	/**
+	 * 원문과 인코딩된 비밀번호가 일치하는지 확인합니다.
+	 *
+	 * @param rawPassword 원문 비밀번호
+	 * @param encodedPassword 암호화된 비밀번호
+	 * @return 일치 여부
+	 */
+	public boolean matches(String rawPassword, String encodedPassword) {
+		return BCrypt.verifyer().verify(rawPassword.toCharArray(), encodedPassword).verified;
+	}
+}

--- a/src/main/java/com/example/outsourcing/config/WebConfig.java
+++ b/src/main/java/com/example/outsourcing/config/WebConfig.java
@@ -1,0 +1,27 @@
+package com.example.outsourcing.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.example.outsourcing.domain.auth.jwt.JwtAuthenticationFilter;
+import com.example.outsourcing.domain.auth.jwt.JwtProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+	private final JwtProvider jwtProvider;
+
+	@Bean
+	public FilterRegistrationBean<JwtAuthenticationFilter> jwtFilter() {
+		FilterRegistrationBean<JwtAuthenticationFilter> registration = new FilterRegistrationBean<>();
+		registration.setFilter(new JwtAuthenticationFilter(jwtProvider));
+		registration.addUrlPatterns("/api/*");
+		registration.setOrder(1);
+		return registration;
+	}
+}

--- a/src/main/java/com/example/outsourcing/domain/Auth/controller/AuthController.java
+++ b/src/main/java/com/example/outsourcing/domain/Auth/controller/AuthController.java
@@ -1,4 +1,0 @@
-package com.example.outsourcing.domain.Auth.controller;
-
-public class AuthController {
-}

--- a/src/main/java/com/example/outsourcing/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/outsourcing/domain/auth/controller/AuthController.java
@@ -1,4 +1,97 @@
-package com.example.outsourcing.domain.Auth.controller;
+package com.example.outsourcing.domain.auth.controller;
 
+import java.time.LocalDateTime;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.outsourcing.common.response.CommonResponse;
+import com.example.outsourcing.config.PasswordEncoder;
+import com.example.outsourcing.domain.auth.dto.AuthResponseDto;
+import com.example.outsourcing.domain.auth.entity.RefreshToken;
+import com.example.outsourcing.domain.auth.jwt.JwtProvider;
+import com.example.outsourcing.domain.auth.repository.RefreshTokenRepository;
+import com.example.outsourcing.domain.user.dto.UserLoginRequestDto;
+import com.example.outsourcing.domain.user.dto.UserResponseDto;
+import com.example.outsourcing.domain.user.entity.User;
+import com.example.outsourcing.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
+
+	private final UserRepository userRepository;
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtProvider jwtProvider;
+
+	/**
+	 * 일반 로그인 (AccessToken + RefreshToken 발급)
+	 */
+	@PostMapping("/login")
+	public CommonResponse<AuthResponseDto> login(@RequestBody UserLoginRequestDto requestDto) {
+		User user = userRepository.findByEmail(requestDto.email())
+			.orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다."));
+
+		if (user.isDeleted()) {
+			throw new IllegalStateException("탈퇴한 사용자입니다.");
+		}
+
+		if (!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
+			throw new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다.");
+		}
+
+		//  Access & Refresh Token 발급
+		String accessToken = jwtProvider.createAccessToken(user.getId());
+		String refreshToken = jwtProvider.createRefreshToken(user.getId());
+
+		//  DB에 RefreshToken 저장 (기존 값이 있다면 갱신)
+		refreshTokenRepository.findByUserId(user.getId()).ifPresentOrElse(
+			existingToken -> existingToken.updateToken(refreshToken, LocalDateTime.now().plusDays(7)),
+			() -> refreshTokenRepository.save(
+				RefreshToken.builder()
+					.user(user)
+					.refreshToken(refreshToken)
+					.expiredAt(LocalDateTime.now().plusDays(7))
+					.build()
+			)
+		);
+
+		UserResponseDto userDto = new UserResponseDto(user.getId(), user.getEmail(), user.getName(), user.getRole());
+		AuthResponseDto responseDto = new AuthResponseDto(accessToken, userDto);
+
+		return CommonResponse.ok(responseDto);
+	}
+
+	/**
+	 * AccessToken 재발급 (RefreshToken 검증)
+	 */
+	@PostMapping("/token/refresh")
+	public CommonResponse<String> refreshToken(@RequestHeader("Authorization") String refreshToken) {
+		RefreshToken saved = refreshTokenRepository.findByRefreshToken(refreshToken)
+			.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다."));
+
+		if (saved.getExpiredAt().isBefore(LocalDateTime.now())) {
+			throw new IllegalStateException("만료된 리프레시 토큰입니다.");
+		}
+
+		String newAccessToken = jwtProvider.createAccessToken(saved.getUser().getId());
+		return CommonResponse.ok(newAccessToken);
+	}
+
+	/**
+	 * 로그아웃 (RefreshToken 삭제)
+	 */
+	@PostMapping("/logout")
+	public CommonResponse<Void> logout(@RequestAttribute("userId") Long userId) {
+		refreshTokenRepository.deleteByUserId(userId);
+		return CommonResponse.ok();
+	}
 }

--- a/src/main/java/com/example/outsourcing/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/example/outsourcing/domain/auth/dto/AuthRequestDto.java
@@ -1,4 +1,0 @@
-package com.example.outsourcing.domain.auth.dto;
-
-public class AuthRequestDto {
-}

--- a/src/main/java/com/example/outsourcing/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/example/outsourcing/domain/auth/dto/AuthResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.outsourcing.domain.auth.dto;
+
+import com.example.outsourcing.domain.user.dto.UserResponseDto;
+
+/**
+ * 로그인 후 응답 DTO: 토큰 + 사용자 정보
+ */
+public record AuthResponseDto(
+	String accessToken,
+	UserResponseDto user
+) {
+}
+

--- a/src/main/java/com/example/outsourcing/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/outsourcing/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,63 @@
+package com.example.outsourcing.domain.auth.entity;
+
+import java.time.LocalDateTime;
+
+import com.example.outsourcing.domain.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자별 리프레시 토큰을 저장하는 엔티티입니다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	/**
+	 * 리프레시 토큰을 소유한 사용자
+	 */
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false, unique = true)
+	private User user;
+
+	/**
+	 * JWT 리프레시 토큰 문자열
+	 */
+	@Column(nullable = false, length = 512)
+	private String refreshToken;
+
+	/**
+	 * 만료 시각
+	 */
+	@Column(nullable = false)
+	private LocalDateTime expiredAt;
+
+	/**
+	 * 토큰 갱신 (재발급 시 사용)
+	 */
+	public void updateToken(String refreshToken, LocalDateTime expiredAt) {
+		this.refreshToken = refreshToken;
+		this.expiredAt = expiredAt;
+	}
+}

--- a/src/main/java/com/example/outsourcing/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/outsourcing/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,38 @@
+package com.example.outsourcing.domain.auth.jwt;
+
+import java.io.IOException;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtProvider jwtProvider;
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+
+		String authHeader = request.getHeader("Authorization");
+
+		if (authHeader != null && authHeader.startsWith("Bearer ")) {
+			String token = authHeader.substring(7);
+
+			if (jwtProvider.validateToken(token)) {
+				Long userId = jwtProvider.getUserId(token);
+				request.setAttribute("userId", userId); // 여기서 주입
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/java/com/example/outsourcing/domain/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/example/outsourcing/domain/auth/jwt/JwtProvider.java
@@ -1,0 +1,81 @@
+package com.example.outsourcing.domain.auth.jwt;
+
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class JwtProvider {
+
+	@Value("${jwt.secret-key}")
+	private String secretKey;
+
+	private Key key;
+
+	private final long ACCESS_EXPIRATION = 1000 * 60 * 60; // 1시간
+
+	@PostConstruct
+	public void init() {
+		this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+	}
+
+	/**
+	 * AccessToken 생성
+	 */
+	public String createAccessToken(Long userId) {
+		Date now = new Date();
+		return Jwts.builder()
+			.setSubject(userId.toString())
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() + ACCESS_EXPIRATION))
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	/**
+	 * JWT에서 userId 추출
+	 */
+	public Long getUserId(String token) {
+		Claims claims = parseClaims(token);
+		return Long.parseLong(claims.getSubject());
+	}
+
+	/**
+	 * 토큰 유효성 검사
+	 */
+	public boolean validateToken(String token) {
+		try {
+			parseClaims(token);
+			return true;
+		} catch (JwtException | IllegalArgumentException e) {
+			return false;
+		}
+	}
+
+	private Claims parseClaims(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+	}
+
+	public String createRefreshToken(Long userId) {
+		Date now = new Date();
+		return Jwts.builder()
+			.setSubject(userId.toString())
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() + (1000L * 60 * 60 * 24 * 7))) // 7일
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+}

--- a/src/main/java/com/example/outsourcing/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/outsourcing/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,16 @@
+package com.example.outsourcing.domain.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.outsourcing.domain.auth.entity.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+	Optional<RefreshToken> findByUserId(Long userId);
+
+	Optional<RefreshToken> findRefreshToken(String refreshToken);
+
+	void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/example/outsourcing/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/outsourcing/domain/user/controller/UserController.java
@@ -1,0 +1,66 @@
+package com.example.outsourcing.domain.user.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.outsourcing.common.response.CommonResponse;
+import com.example.outsourcing.domain.user.dto.UserResponseDto;
+import com.example.outsourcing.domain.user.dto.UserSignUpRequestDto;
+import com.example.outsourcing.domain.user.service.UserService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	/**
+	 * 회원가입
+	 */
+	@PostMapping("/auth/signup")
+	public CommonResponse<UserResponseDto> signUp(@RequestBody @Valid UserSignUpRequestDto requestDto) {
+		UserResponseDto result = userService.signUp(requestDto);
+		return CommonResponse.created(result);  // 201 Created
+	}
+
+	/**
+	 * 회원 탈퇴
+	 */
+	@DeleteMapping("/users/withdraw")
+	public CommonResponse<Void> withdraw(
+		@RequestParam String email,
+		@RequestParam String password
+	) {
+		userService.withdraw(email, password);
+		return CommonResponse.ok();  // 200 OK
+	}
+
+	/**
+	 * 마이페이지 (본인 정보 조회)
+	 */
+	@GetMapping("/users/me")
+	public CommonResponse<UserResponseDto> getMyInfo(@RequestAttribute("userId") Long userId) {
+		UserResponseDto result = userService.getMyInfo(userId);
+		return CommonResponse.ok(result);  // 200 OK
+	}
+
+	/**
+	 * 사용자 단건 조회 (관리자용)
+	 */
+	@GetMapping("/users/{id}")
+	public CommonResponse<UserResponseDto> getUserById(@PathVariable Long id) {
+		UserResponseDto result = userService.getUserById(id);
+		return CommonResponse.ok(result);  // 200 OK
+	}
+}

--- a/src/main/java/com/example/outsourcing/domain/user/dto/UserLoginRequestDto.java
+++ b/src/main/java/com/example/outsourcing/domain/user/dto/UserLoginRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.outsourcing.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 로그인 요청을 위한 DTO
+ */
+public record UserLoginRequestDto(
+
+	@Email(message = "이메일 형식이 아닙니다.")
+	@NotBlank(message = "이메일은 필수입니다.")
+	String email,
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	String password
+) {
+}

--- a/src/main/java/com/example/outsourcing/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/example/outsourcing/domain/user/dto/UserRequestDto.java
@@ -1,4 +1,0 @@
-package com.example.outsourcing.domain.user.dto;
-
-public class UserRequestDto {
-}

--- a/src/main/java/com/example/outsourcing/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/example/outsourcing/domain/user/dto/UserResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.outsourcing.domain.user.dto;
+
+import com.example.outsourcing.domain.user.entity.Role;
+
+/**
+ * 사용자 정보를 응답하기 위한 DTO입니다.
+ */
+public record UserResponseDto(
+	Long id,
+	String email,
+	String nickname,
+	Role role
+) {
+}

--- a/src/main/java/com/example/outsourcing/domain/user/dto/UserSignUpRequestDto.java
+++ b/src/main/java/com/example/outsourcing/domain/user/dto/UserSignUpRequestDto.java
@@ -1,0 +1,32 @@
+package com.example.outsourcing.domain.user.dto;
+
+import com.example.outsourcing.domain.user.entity.Role;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 회원가입 요청을 위한 DTO
+ */
+public record UserSignUpRequestDto(
+
+	@Email(message = "이메일 형식이 아닙니다.")
+	@NotBlank(message = "이메일은 필수입니다.")
+	String email,
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	@Pattern(
+		regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$",
+		message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다."
+	)
+	String password,
+
+	@NotBlank(message = "닉네임은 필수입니다.")
+	@Size(max = 50)
+	String nickname,
+
+	Role role
+) {
+}

--- a/src/main/java/com/example/outsourcing/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/outsourcing/domain/user/repository/UserRepository.java
@@ -1,0 +1,38 @@
+package com.example.outsourcing.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.outsourcing.domain.user.entity.User;
+
+/**
+ * 사용자 정보를 조회/저장하기 위한 JPA Repository 인터페이스입니다.
+ */
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	/**
+	 * 이메일로 사용자 조회
+	 *
+	 * @param email 이메일
+	 * @return Optional<User>
+	 */
+	Optional<User> findByEmail(String email);
+
+	/**
+	 * OAuth providerId로 사용자 조회
+	 *
+	 * @param providerId 외부 OAuth 제공자의 사용자 ID
+	 * @return Optional<User>
+	 */
+	Optional<User> findByProviderId(String providerId);
+
+	/**
+	 * 탈퇴 여부 포함하여 이메일로 조회
+	 *
+	 * @param email 이메일
+	 * @param isDeleted 삭제 여부
+	 * @return Optional<User>
+	 */
+	Optional<User> findByEmailAndIsDeleted(String email, boolean isDeleted);
+}

--- a/src/main/java/com/example/outsourcing/domain/user/service/UserService.java
+++ b/src/main/java/com/example/outsourcing/domain/user/service/UserService.java
@@ -1,0 +1,42 @@
+package com.example.outsourcing.domain.user.service;
+
+import com.example.outsourcing.domain.user.dto.UserResponseDto;
+import com.example.outsourcing.domain.user.dto.UserSignUpRequestDto;
+
+/**
+ * 사용자 관련 서비스 인터페이스입니다.
+ */
+public interface UserService {
+
+	/**
+	 * 회원가입을 처리합니다.
+	 *
+	 * @param request 회원가입 요청 DTO
+	 * @return 가입된 사용자 정보
+	 */
+	UserResponseDto signUp(UserSignUpRequestDto request);
+
+	/**
+	 * 마이페이지 - 본인 정보 조회
+	 *
+	 * @param userId 현재 로그인한 사용자 ID
+	 * @return 사용자 응답 DTO
+	 */
+	UserResponseDto getMyInfo(Long userId);
+
+	/**
+	 * 사용자 탈퇴 처리 (soft delete)
+	 *
+	 * @param email 이메일
+	 * @param password 비밀번호
+	 */
+	void withdraw(String email, String password);
+
+	/**
+	 * 사용자 단건 조회 (관리자용 또는 상세페이지용)
+	 *
+	 * @param userId 사용자 ID
+	 * @return 사용자 정보
+	 */
+	UserResponseDto getUserById(Long userId);
+}

--- a/src/main/java/com/example/outsourcing/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/outsourcing/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,91 @@
+package com.example.outsourcing.domain.user.service;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.outsourcing.config.PasswordEncoder;
+import com.example.outsourcing.domain.user.dto.UserResponseDto;
+import com.example.outsourcing.domain.user.dto.UserSignUpRequestDto;
+import com.example.outsourcing.domain.user.entity.Role;
+import com.example.outsourcing.domain.user.entity.User;
+import com.example.outsourcing.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 사용자 관련 서비스 구현체입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	@Transactional
+	public UserResponseDto signUp(UserSignUpRequestDto request) {
+		if (userRepository.findByEmail(request.email()).isPresent()) {
+			throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+		}
+
+		String encodedPassword = passwordEncoder.encode(request.password());
+
+		User user = User.builder()
+			.email(request.email())
+			.password(encodedPassword)
+			.name(request.nickname())
+			.role(request.role() != null ? request.role() : Role.USER)
+			.build();
+
+		User savedUser = userRepository.save(user);
+		return toDto(savedUser);
+	}
+
+	@Override
+	@Transactional
+	public void withdraw(String email, String password) {
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+		if (user.isDeleted()) {
+			throw new IllegalStateException("이미 탈퇴한 사용자입니다.");
+		}
+
+		if (!passwordEncoder.matches(password, user.getPassword())) {
+			throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+		}
+
+		user.delete(); // soft delete
+	}
+
+	@Override
+	@Transactional
+	public UserResponseDto getMyInfo(Long userId) {
+		User user = userRepository.findById(userId)
+			.filter(u -> !u.isDeleted())
+			.orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+		return toDto(user);
+	}
+
+	@Override
+	@Transactional
+	public UserResponseDto getUserById(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+		return toDto(user);
+	}
+
+	private UserResponseDto toDto(User user) {
+		return new UserResponseDto(
+			user.getId(),
+			user.getEmail(),
+			user.getName(),
+			user.getRole()
+		);
+	}
+}


### PR DESCRIPTION
## 🔎 작업 내용

- AccessToken / RefreshToken 발급

- 로그인 성공 시 RefreshToken 저장

- AccessToken 재발급 API (`/token/refresh`)

- 로그아웃 시 RefreshToken 삭제

- @RequestAttribute("userId") 기반 사용자 식별 구조 확립

- JwtAuthenticationFilter + WebConfig 필터 등록

  <br/>

## ➕ 트러블 슈팅

- JwtProvider 빈 주입이 되지 않아 @Component 누락 확인 및 패키지 위치 조정

- FilterRegistrationBean에서 타입 미스매치 오류 → 제네릭 명시 (Filter → JwtAuthenticationFilter)

- AccessToken에 담긴 userId를 필터에서 request에 직접 주입하여 인증 상태 전달 구조 완성

- refreshToken 중복 저장 방지를 위해 findByUserId 후 updateToken 적용

  <br/>

## 🔧 해결해야할 문제

- 현재 RefreshToken은 DB에 저장되며, 추후 Redis로 리팩토링 고려 가능

- 테스트 및 OAuth 로그인 흐름과의 통합은 추후 예정

  <br/>

<br/>