### PR TITLE
[FEAT] 메뉴 CRUD 구현 완료

### DIFF
--- a/src/main/java/com/example/outsourcing/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/outsourcing/common/exception/ErrorCode.java
@@ -8,13 +8,20 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode implements BaseCode {
 
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "유효하지 않은 입력 값입니다."),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "허용되지 않은 요청 방식입니다."),
-    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "요청한 엔티티를 찾을 수 없습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "내부 서버 오류가 발생했습니다."),
-    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C005", "유효하지 않은 타입의 값입니다.");
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "유효하지 않은 입력 값입니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "허용되지 않은 요청 방식입니다."),
+	ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "요청한 엔티티를 찾을 수 없습니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "내부 서버 오류가 발생했습니다."),
+	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C005", "유효하지 않은 타입의 값입니다."),
 
-    private final HttpStatus httpStatus;
-    private final String code;
-    private final String message;
+	// 메뉴 도메인 에러코드 (추가)
+	MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 메뉴가 존재하지 않습니다."),
+	STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "해당 가게가 존재하지 않습니다."),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "C006", "권한이 없습니다."),
+	ALREADY_DELETED_MENU(HttpStatus.CONFLICT, "M002", "이미 삭제된 메뉴입니다.");
+
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
 }

--- a/src/main/java/com/example/outsourcing/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/controller/MenuController.java
@@ -1,0 +1,69 @@
+package com.example.outsourcing.domain.menu.controller;
+
+import com.example.outsourcing.common.response.CommonResponse;
+import com.example.outsourcing.domain.menu.dto.MenuCreateRequest;
+import com.example.outsourcing.domain.menu.dto.MenuResponse;
+import com.example.outsourcing.domain.menu.dto.MenuResultResponse;
+import com.example.outsourcing.domain.menu.dto.MenuUpdateRequest;
+import com.example.outsourcing.domain.menu.service.MenuService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/menus")
+public class MenuController {
+
+	private final MenuService menuService;
+
+	// 메뉴 생성 API
+	@PostMapping
+	public ResponseEntity<CommonResponse<MenuResultResponse>> createMenu(
+			@RequestBody @Valid MenuCreateRequest request
+	) {
+		Long currentUserId = 1L; // 임시 하드코딩 (인증 연동 시 수정 예정)
+		MenuResultResponse response = menuService.create(request, currentUserId);
+		return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.created(response));
+	}
+
+	// 가게 메뉴 조회 API
+	@GetMapping("/stores/{storeId}/menus")
+	public ResponseEntity<CommonResponse<List<MenuResponse>>> getMenusByStore(
+			@PathVariable Long storeId
+	) {
+		List<MenuResponse> menus = menuService.getMenusByStore(storeId);
+		return ResponseEntity.ok(CommonResponse.ok(menus));
+	}
+
+	// 메뉴 수정 API
+	@PutMapping("/{menuId}")
+	public ResponseEntity<CommonResponse<MenuResultResponse>> updateMenu(
+			@PathVariable Long menuId,
+			@RequestBody @Valid MenuUpdateRequest request
+	) {
+		Long currentUserId = 1L;
+		MenuResultResponse response = menuService.update(menuId, request, currentUserId);
+		return ResponseEntity.ok(CommonResponse.ok(response));
+	}
+
+	// 메뉴 삭제 API
+	@DeleteMapping("/{menuId}")
+	public ResponseEntity<CommonResponse<MenuResultResponse>> deleteMenu(
+			@PathVariable Long menuId
+	) {
+		Long currentUserId = 1L;
+		MenuResultResponse response = menuService.delete(menuId, currentUserId);
+		return ResponseEntity.ok(CommonResponse.ok(response));
+	}
+}

--- a/src/main/java/com/example/outsourcing/domain/menu/dto/MenuCreateRequest.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/dto/MenuCreateRequest.java
@@ -1,0 +1,26 @@
+package com.example.outsourcing.domain.menu.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MenuCreateRequest {
+
+	@NotNull(message = "가게 ID는 필수입니다.")
+	private Long storeId;
+
+
+	@NotBlank(message = "메뉴 이름은 필수입니다.")
+	private String name;
+
+
+	@Positive(message = "가격은 0보다 커야 합니다.")
+	private int price;
+
+
+	private String description;
+}

--- a/src/main/java/com/example/outsourcing/domain/menu/dto/MenuResponse.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/dto/MenuResponse.java
@@ -1,0 +1,24 @@
+package com.example.outsourcing.domain.menu.dto;
+
+import com.example.outsourcing.domain.menu.entity.Menu;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MenuResponse {
+
+	private Long menuId;
+	private String name;
+	private int price;
+	private String description;
+
+	public static MenuResponse from(Menu menu) {
+		return new MenuResponse(
+				menu.getId(),
+				menu.getName(),
+				menu.getPrice(),
+				menu.getDescription()
+		);
+	}
+}

--- a/src/main/java/com/example/outsourcing/domain/menu/dto/MenuResultResponse.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/dto/MenuResultResponse.java
@@ -1,0 +1,12 @@
+package com.example.outsourcing.domain.menu.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MenuResultResponse {
+
+	private Long menuId;
+	private String message;
+}

--- a/src/main/java/com/example/outsourcing/domain/menu/dto/MenuUpdateRequest.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/dto/MenuUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.example.outsourcing.domain.menu.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MenuUpdateRequest {
+
+	@NotBlank(message = "메뉴 이름은 필수입니다.")
+	private String name;
+
+	@Positive(message = "가격은 0보다 커야 합니다.")
+	private int price;
+
+	private String description;
+}

--- a/src/main/java/com/example/outsourcing/domain/menu/entity/Menu.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/entity/Menu.java
@@ -1,0 +1,61 @@
+package com.example.outsourcing.domain.menu.entity;
+
+import com.example.outsourcing.domain.store.entity.Store;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Menu {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id", nullable = false)
+	private Store store;
+
+	private String name;
+
+	private int price;
+
+	private String description;
+
+	@Enumerated(EnumType.STRING)
+	private Status status = Status.ACTIVE;
+
+	public enum Status {
+		ACTIVE, DELETED
+	}
+
+	public Menu(Store store, String name, int price, String description) {
+		this.store = store;
+		this.name = name;
+		this.price = price;
+		this.description = description;
+		this.status = Status.ACTIVE;
+	}
+
+	public void update(String name, int price, String description) {
+		this.name = name;
+		this.price = price;
+		this.description = description;
+	}
+
+	public void delete() {
+		this.status = Status.DELETED;
+	}
+
+}

--- a/src/main/java/com/example/outsourcing/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/repository/MenuRepository.java
@@ -1,0 +1,1 @@
+package com.example.outsourcing.domain.menu.repository;import com.example.outsourcing.domain.menu.entity.Menu;import java.util.List;import org.springframework.data.jpa.repository.JpaRepository;public interface MenuRepository extends JpaRepository<Menu, Long> {	// 특정 가게의 메뉴만 조회	List<Menu> findByStatusAndStoreId(Menu.Status status, Long storeId);}

--- a/src/main/java/com/example/outsourcing/domain/menu/service/MenuService.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/service/MenuService.java
@@ -1,0 +1,76 @@
+package com.example.outsourcing.domain.menu.service;
+
+import com.example.outsourcing.common.exception.CustomException;
+import com.example.outsourcing.common.exception.ErrorCode;
+import com.example.outsourcing.domain.menu.dto.MenuCreateRequest;
+import com.example.outsourcing.domain.menu.dto.MenuResponse;
+import com.example.outsourcing.domain.menu.dto.MenuResultResponse;
+import com.example.outsourcing.domain.menu.dto.MenuUpdateRequest;
+import com.example.outsourcing.domain.menu.entity.Menu;
+import com.example.outsourcing.domain.menu.repository.MenuRepository;
+import com.example.outsourcing.domain.store.entity.Store;
+import com.example.outsourcing.domain.store.repository.StoreRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MenuService {
+
+	private final MenuRepository menuRepository;
+	private final StoreRepository storeRepository;
+
+
+	public MenuResultResponse create(MenuCreateRequest request, Long currentUserId) {
+		Store store = storeRepository.findById(request.getStoreId())
+				.orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+
+		if (!store.getUser().getId().equals(currentUserId)) {
+			throw new CustomException(ErrorCode.FORBIDDEN);
+		}
+
+		Menu menu = new Menu(store, request.getName(), request.getPrice(),
+				request.getDescription());
+		Menu saved = menuRepository.save(menu);
+
+		return new MenuResultResponse(saved.getId(), "메뉴가 등록되었습니다.");
+	}
+
+	public List<MenuResponse> getMenusByStore(Long storeId) {
+		List<Menu> menus = menuRepository.findByStatusAndStoreId(Menu.Status.ACTIVE, storeId);
+		return menus.stream().map(MenuResponse::from).toList();
+	}
+
+	public MenuResultResponse update(Long menuId, MenuUpdateRequest request, Long currentUserId) {
+		Menu menu = menuRepository.findById(menuId)
+				.orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+		if (menu.getStatus() == Menu.Status.DELETED) {
+			throw new CustomException(ErrorCode.ALREADY_DELETED_MENU);
+		}
+
+		if (!menu.getStore().getUser().getId().equals(currentUserId)) {
+			throw new CustomException(ErrorCode.FORBIDDEN);
+		}
+
+		menu.update(request.getName(), request.getPrice(), request.getDescription());
+		return new MenuResultResponse(menu.getId(), "메뉴가 수정되었습니다.");
+	}
+
+	public MenuResultResponse delete(Long menuId, Long currentUserId) {
+		Menu menu = menuRepository.findById(menuId)
+				.orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+		if (menu.getStatus() == Menu.Status.DELETED) {
+			throw new CustomException(ErrorCode.ALREADY_DELETED_MENU);
+		}
+
+		if (!menu.getStore().getUser().getId().equals(currentUserId)) {
+			throw new CustomException(ErrorCode.FORBIDDEN);
+		}
+
+		menu.delete();
+		return new MenuResultResponse(menu.getId(), "메뉴가 삭제되었습니다.");
+	}
+}


### PR DESCRIPTION
## 🔎 작업 내용

메뉴 등록, 수정, 삭제, 조회 기능 구현
메뉴 상태(활성,삭제) 기반 조회
메뉴 삭제시 soft delete 처리
로그인된 사용자와 store 소유자 일치 여부 확인후 기능 수행


## ➕ 트러블 슈팅
MenuRepository에서 findByStatusAndStoreId를 findByStoreIdAndStatus로 Storeld와 Status의 순서를 잘못 작성하여 쿼리 자동 생성 오류 발생, 순서를 변경하여 해결
MenuRepository를 내부 클래스에 잘못 작성해 의존성 주입 실패 발생. 별도 클래스로 분리 후 정상 인식


