### PR TITLE
[FEAT] 메뉴에 로그인 연동 및 에러코드 메뉴 도메인으로 이동

### DIFF
--- a/src/main/java/com/example/outsourcing/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/outsourcing/common/exception/ErrorCode.java
@@ -12,13 +12,7 @@ public enum ErrorCode implements BaseCode {
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "허용되지 않은 요청 방식입니다."),
 	ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "요청한 엔티티를 찾을 수 없습니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "내부 서버 오류가 발생했습니다."),
-	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C005", "유효하지 않은 타입의 값입니다."),
-
-	// 메뉴 도메인 에러코드 (추가)
-	MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 메뉴가 존재하지 않습니다."),
-	STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "해당 가게가 존재하지 않습니다."),
-	FORBIDDEN(HttpStatus.FORBIDDEN, "C006", "권한이 없습니다."),
-	ALREADY_DELETED_MENU(HttpStatus.CONFLICT, "M002", "이미 삭제된 메뉴입니다.");
+	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C005", "유효하지 않은 타입의 값입니다.");
 
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/example/outsourcing/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/controller/MenuController.java
@@ -9,13 +9,12 @@ import com.example.outsourcing.domain.menu.service.MenuService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,43 +26,49 @@ public class MenuController {
 
 	private final MenuService menuService;
 
-	// 메뉴 생성 API
+	/**
+	 * 메뉴를 생성하는 API. 로그인된 사용자의 ID를 기반으로, 해당 사용자가 소유한 가게에만 메뉴를 생성
+	 */
 	@PostMapping
-	public ResponseEntity<CommonResponse<MenuResultResponse>> createMenu(
-			@RequestBody @Valid MenuCreateRequest request
+	public CommonResponse<MenuResultResponse> createMenu(
+			@RequestBody @Valid MenuCreateRequest request,
+			@RequestAttribute("userId") Long currentUserId
 	) {
-		Long currentUserId = 1L; // 임시 하드코딩 (인증 연동 시 수정 예정)
-		MenuResultResponse response = menuService.create(request, currentUserId);
-		return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.created(response));
+		return CommonResponse.created(menuService.create(request, currentUserId));
 	}
 
-	// 가게 메뉴 조회 API
+	/**
+	 * 가게의 메뉴 목록을 조회하는 API. 메뉴는 활성상태인 경우에만 조회
+	 */
 	@GetMapping("/stores/{storeId}/menus")
-	public ResponseEntity<CommonResponse<List<MenuResponse>>> getMenusByStore(
+	public CommonResponse<List<MenuResponse>> getMenusByStore(
 			@PathVariable Long storeId
 	) {
-		List<MenuResponse> menus = menuService.getMenusByStore(storeId);
-		return ResponseEntity.ok(CommonResponse.ok(menus));
+		return CommonResponse.ok(menuService.getMenusByStore(storeId));
 	}
 
-	// 메뉴 수정 API
+	/**
+	 * 메뉴 정보를 수정하는 API. 메뉴가 소속된 가게의 오너와 로그인 사용자가 일치할 때만 수정가능
+	 */
+
 	@PutMapping("/{menuId}")
-	public ResponseEntity<CommonResponse<MenuResultResponse>> updateMenu(
+	public CommonResponse<MenuResultResponse> updateMenu(
 			@PathVariable Long menuId,
-			@RequestBody @Valid MenuUpdateRequest request
+			@RequestBody @Valid MenuUpdateRequest request,
+			@RequestAttribute("userId") Long currentUserId
 	) {
-		Long currentUserId = 1L;
-		MenuResultResponse response = menuService.update(menuId, request, currentUserId);
-		return ResponseEntity.ok(CommonResponse.ok(response));
+		return CommonResponse.ok(menuService.update(menuId, request, currentUserId));
 	}
 
-	// 메뉴 삭제 API
+	/**
+	 * 메뉴를 삭제하는 API. 실제 삭제가 아닌 Soft Delete 방식으로 상태를 deleted로 변경. 메뉴가 소속된 가게의 오너와 로그인 사용자가 일치할
+	 * 때만삭제가능
+	 */
 	@DeleteMapping("/{menuId}")
-	public ResponseEntity<CommonResponse<MenuResultResponse>> deleteMenu(
-			@PathVariable Long menuId
+	public CommonResponse<MenuResultResponse> deleteMenu(
+			@PathVariable Long menuId,
+			@RequestAttribute("userId") Long currentUserId
 	) {
-		Long currentUserId = 1L;
-		MenuResultResponse response = menuService.delete(menuId, currentUserId);
-		return ResponseEntity.ok(CommonResponse.ok(response));
+		return CommonResponse.ok(menuService.delete(menuId, currentUserId));
 	}
 }

--- a/src/main/java/com/example/outsourcing/domain/menu/exception/MenuErrorCode.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/exception/MenuErrorCode.java
@@ -1,0 +1,38 @@
+package com.example.outsourcing.domain.menu.exception;
+
+import com.example.outsourcing.common.exception.BaseCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MenuErrorCode implements BaseCode {
+	MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 메뉴가 존재하지 않습니다."),
+	STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "해당 가게가 존재하지 않습니다."),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "C006", "권한이 없습니다."),
+	ALREADY_DELETED_MENU(HttpStatus.CONFLICT, "M002", "이미 삭제된 메뉴입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+	MenuErrorCode(HttpStatus httpStatus, String code, String message) {
+		this.httpStatus = httpStatus;
+		this.code = code;
+		this.message = message;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/com/example/outsourcing/domain/menu/service/MenuService.java
+++ b/src/main/java/com/example/outsourcing/domain/menu/service/MenuService.java
@@ -1,12 +1,12 @@
 package com.example.outsourcing.domain.menu.service;
 
 import com.example.outsourcing.common.exception.CustomException;
-import com.example.outsourcing.common.exception.ErrorCode;
 import com.example.outsourcing.domain.menu.dto.MenuCreateRequest;
 import com.example.outsourcing.domain.menu.dto.MenuResponse;
 import com.example.outsourcing.domain.menu.dto.MenuResultResponse;
 import com.example.outsourcing.domain.menu.dto.MenuUpdateRequest;
 import com.example.outsourcing.domain.menu.entity.Menu;
+import com.example.outsourcing.domain.menu.exception.MenuErrorCode;
 import com.example.outsourcing.domain.menu.repository.MenuRepository;
 import com.example.outsourcing.domain.store.entity.Store;
 import com.example.outsourcing.domain.store.repository.StoreRepository;
@@ -21,13 +21,15 @@ public class MenuService {
 	private final MenuRepository menuRepository;
 	private final StoreRepository storeRepository;
 
-
+	/**
+	 * 메뉴를 생성하고 가게 존재 여부 확인 및 로그인 사용자와 해당 가게 오너의 일치 여부 확인 후 메뉴 엔티티 생성 및 저장
+	 */
 	public MenuResultResponse create(MenuCreateRequest request, Long currentUserId) {
 		Store store = storeRepository.findById(request.getStoreId())
-				.orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+				.orElseThrow(() -> new CustomException(MenuErrorCode.STORE_NOT_FOUND));
 
 		if (!store.getUser().getId().equals(currentUserId)) {
-			throw new CustomException(ErrorCode.FORBIDDEN);
+			throw new CustomException(MenuErrorCode.FORBIDDEN);
 		}
 
 		Menu menu = new Menu(store, request.getName(), request.getPrice(),
@@ -37,37 +39,48 @@ public class MenuService {
 		return new MenuResultResponse(saved.getId(), "메뉴가 등록되었습니다.");
 	}
 
+	/**
+	 * 가게의 메뉴 목록 조회
+	 */
+
 	public List<MenuResponse> getMenusByStore(Long storeId) {
 		List<Menu> menus = menuRepository.findByStatusAndStoreId(Menu.Status.ACTIVE, storeId);
 		return menus.stream().map(MenuResponse::from).toList();
 	}
 
+	/**
+	 * 삭제된 메뉴는 수정이 불가능하며 사용자가 가게의 오너일 경우에만 수정가능.
+	 */
+
 	public MenuResultResponse update(Long menuId, MenuUpdateRequest request, Long currentUserId) {
 		Menu menu = menuRepository.findById(menuId)
-				.orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+				.orElseThrow(() -> new CustomException(MenuErrorCode.MENU_NOT_FOUND));
 
 		if (menu.getStatus() == Menu.Status.DELETED) {
-			throw new CustomException(ErrorCode.ALREADY_DELETED_MENU);
+			throw new CustomException(MenuErrorCode.ALREADY_DELETED_MENU);
 		}
 
 		if (!menu.getStore().getUser().getId().equals(currentUserId)) {
-			throw new CustomException(ErrorCode.FORBIDDEN);
+			throw new CustomException(MenuErrorCode.FORBIDDEN);
 		}
 
 		menu.update(request.getName(), request.getPrice(), request.getDescription());
 		return new MenuResultResponse(menu.getId(), "메뉴가 수정되었습니다.");
 	}
 
+	/**
+	 * 삭제된 메뉴는 중복삭제가 불가능하며 사용자가 가게의 오너일 경우에만 삭제가능.(soft delete)
+	 */
 	public MenuResultResponse delete(Long menuId, Long currentUserId) {
 		Menu menu = menuRepository.findById(menuId)
-				.orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+				.orElseThrow(() -> new CustomException(MenuErrorCode.MENU_NOT_FOUND));
 
 		if (menu.getStatus() == Menu.Status.DELETED) {
-			throw new CustomException(ErrorCode.ALREADY_DELETED_MENU);
+			throw new CustomException(MenuErrorCode.ALREADY_DELETED_MENU);
 		}
 
 		if (!menu.getStore().getUser().getId().equals(currentUserId)) {
-			throw new CustomException(ErrorCode.FORBIDDEN);
+			throw new CustomException(MenuErrorCode.FORBIDDEN);
 		}
 
 		menu.delete();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,22 +1,19 @@
 spring.application.name=outsourcing
-
-#DataSource
-spring.datasource.url=jdbc:mysql://localhost:3306/${DB_NAME}?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
-spring.datasource.username=${DB_USERNAME}
-spring.datasource.password=${DB_PASSWORD}
+# ? ?? ??? ??
+spring.datasource.url=jdbc:mysql://localhost:3306/outsourcing?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+spring.datasource.username=root
+spring.datasource.password=rlaxogud12!
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
 #Hibernate
 spring.jpa.hibernate.ddl-auto=update
-
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
-
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 server.error.include-message=always
-
-
-jwt.secret-key=${JWT_SECRET_KEY}
+# ? JWT ??? ?? 256?? ?? (32? ??)
+jwt.secret-key=12345678901234567890123456789012
 jwt.expiration=3600000
 jwt.refresh-expiration=604800000
+
+


### PR DESCRIPTION

## 🔎 작업 내용

MenuController에서 userId 하드코딩 방식 제거 후 RequestAttribute 적용
MenuService에서 store.getUser().getId()와 비교후 권한 확인
MenuErrorCode를 공통 도메인에서 메뉴 도메인 내부로 이동

  <br/>

## ➕ 트러블 슈팅

Postman에서 로그인 테스트시 "이메일 또는 비밀번호가 일치하지 않습니다"라는 오류가 계속 발생했는데
DB에 저장된 암호화된 비밀번호가 애플리케이션 암호화 로직과 맞지 않은 이유.
직접 테스트 클래슬르 만들어 암호화하고 해당값으로 DB갱신
메뉴 생성시 store를 조회한 뒤 비교하는 로직에서 store에 user가 null값이 되어있어서 오류 발생
DB에서 해당 가게에 user_id를 수동으로 설정해서 해결

  <br/>

## 🔧 해결해야할 문제

- 구현이나 동작에는 문제가 없지만
- 리팩토링이나 사소한 문제가 있다면 이곳에 적어주세요.

  <br/>

<br/>